### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 ![CVE-SEARCH_MCP](https://socialify.git.ci/roadwy/cve-search_mcp/image?name=1&theme=Light)
 
+<a href="https://glama.ai/mcp/servers/@roadwy/cve-search_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@roadwy/cve-search_mcp/badge" alt="cve-search_mcp MCP server" />
+</a>
+
 A Model Context Protocol (MCP) server for querying the [CVE-Search](https://www.cve-search.org/api/) API. This server provides comprehensive access to CVE-Search, browse vendor and product、get CVE per CVE-ID、get the last updated CVEs.
 
 ## Requirements
@@ -17,8 +21,6 @@ A Model Context Protocol (MCP) server for querying the [CVE-Search](https://www.
 - To get a JSON of a specific CVE ID
 - To get a JSON of the last 30 CVEs including CAPEC, CWE and CPE expansions
 - To get more information about the current databases in use and when it was updated
-
-
 
 ## Quick Start
 1. Git clone this repository


### PR DESCRIPTION
This PR adds a badge for the [cve-search_mcp](https://glama.ai/mcp/servers/@roadwy/cve-search_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@roadwy/cve-search_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@roadwy/cve-search_mcp/badge" alt="cve-search_mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.