### PR TITLE
fix: vul_last_cves Tool Response

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 # https://github.com/roadwy
 from mcp.server.fastmcp import FastMCP
 import requests
-from typing import Dict, Any
+from typing import Dict, Any, List
 import logging
 
 
@@ -11,7 +11,7 @@ mcp = FastMCP("cve-search_mcp")
 logger = logging.getLogger(__name__)
 logger.info("Starting cve-search_mcp")
 
-    
+
 def get_requests(uri: str) -> Dict[str, Any]:
     """To get a JSON with all the requests"""
     session = requests.Session()
@@ -23,6 +23,8 @@ def get_requests(uri: str) -> Dict[str, Any]:
     except requests.exceptions.RequestException as e:
         logger.error(f"api request failed: {url} - {str(e)}")
         return {"error": str(e)}
+
+
 @mcp.tool()
 def vul_vendors() -> Dict[str, Any]:
     """
@@ -30,17 +32,18 @@ def vul_vendors() -> Dict[str, Any]:
     """
     return get_requests("browse")
 
+
 @mcp.tool()
-def vul_vendor_products(vendor:str) -> Dict[str, Any]:
+def vul_vendor_products(vendor: str) -> Dict[str, Any]:
     """
     To get a JSON with all the products associated to a vendor
     """
     uri = f"browse/{vendor}"
     return get_requests(uri)
 
-    
+
 @mcp.tool()
-def vul_vendor_product_cve(vendor:str, product:str) -> Dict[str, Any]:
+def vul_vendor_product_cve(vendor: str, product: str) -> Dict[str, Any]:
     """
     To get a JSON with all the vulnerabilities per vendor and a specific product
     """
@@ -49,7 +52,7 @@ def vul_vendor_product_cve(vendor:str, product:str) -> Dict[str, Any]:
 
 
 @mcp.tool()
-def vul_cve_search(cve_id:str) -> Dict[str, Any]:
+def vul_cve_search(cve_id: str) -> Dict[str, Any]:
     """
     To get a JSON of a specific CVE ID
     """
@@ -58,11 +61,11 @@ def vul_cve_search(cve_id:str) -> Dict[str, Any]:
 
 
 @mcp.tool()
-def vul_last_cves() -> Dict[str, Any]:
+def vul_last_cves(number: int = 5) -> List[Dict[str, Any]]:
     """
-    To get a JSON of the last 30 CVEs including CAPEC, CWE and CPE expansions
+    To get a JSON of the last <number> (5 by default) CVEs including CAPEC, CWE and CPE expansions
     """
-    uri = f"last"
+    uri = f"last/{number}"
     return get_requests(uri)
 
 
@@ -76,8 +79,8 @@ def vul_db_update_status() -> Dict[str, Any]:
 
 
 def main():
-    #mcp.run(transport='sse')
-    mcp.run(transport='stdio')
+    # mcp.run(transport='sse')
+    mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It appears that the response returned is a list of dictionaries instead
of a dictionary.

Update tool to fetch only 5 CVEs by default, it could be overridden by
passing a number as an argument to the tool.
